### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit -r . || true
+      - run: black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --ignore-missing-imports . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -16,5 +16,5 @@ jobs:
       - run: mypy --ignore-missing-imports .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt
-      - run: mypy --ignore-missing-imports . || true
+      - run: mypy --ignore-missing-imports .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,12 +7,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit -r . || true
+      - run: bandit -r .
       - run: black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2 --skip="*.js" || true  # --ignore-words-list=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements.txt
       - run: mypy --ignore-missing-imports . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: codespell --ignore-words-list="adn,nd" --quiet-level=2 --skip="*.js"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt
+      - run: pip install sphinx_rtd_theme -r requirements.txt
       - run: mypy --ignore-missing-imports .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r .
       - run: black --check . || true
-      - run: codespell --quiet-level=2 --skip="*.js" || true  # --ignore-words-list=""
+      - run: codespell --ignore-words-list="adn,nd" --quiet-level=2 --skip="*.js"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt

--- a/directory_tree/directory_node.py
+++ b/directory_tree/directory_node.py
@@ -138,8 +138,4 @@ class DirectoryNode(Node):
             raise ValueError(f"Invalid argument {query}")
 
         match = self.search(query)
-
-        if match:
-            return match.directory_path()
-        else:
-            return
+        return match.directory_path() if match else ""

--- a/directory_tree/examples/__init__.py
+++ b/directory_tree/examples/__init__.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 
 """

--- a/directory_tree/examples/speed_test.py
+++ b/directory_tree/examples/speed_test.py
@@ -84,6 +84,8 @@ class SpotMapping:
 
             path = os.path.dirname(path)
 
+        return path
+
 
 def main():
     #######################

--- a/directory_tree/examples/speed_test.py
+++ b/directory_tree/examples/speed_test.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 Speed test using the archive spot directory to provide an example
 """

--- a/docs/_sources/index.rst.txt
+++ b/docs/_sources/index.rst.txt
@@ -8,7 +8,7 @@ Welcome to directory-tree's documentation!
 
 This package can be used to optimise directory and dataset lookup tables.
 
-Speed comparison agains a recursive lookup approach, shortening the path by
+Speed comparison against a recursive lookup approach, shortening the path by
 one each time and re-testing:
 
 .. program-output:: directory-tree-speed-test

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,7 +159,7 @@
   <div class="section" id="welcome-to-directory-tree-s-documentation">
 <h1>Welcome to directory-tree’s documentation!<a class="headerlink" href="#welcome-to-directory-tree-s-documentation" title="Permalink to this headline">¶</a></h1>
 <p>This package can be used to optimise directory and dataset lookup tables.</p>
-<p>Speed comparison agains a recursive lookup approach, shortening the path by
+<p>Speed comparison against a recursive lookup approach, shortening the path by
 one each time and re-testing:</p>
 <div class="highlight-text notranslate"><div class="highlight"><pre><span></span>Directory Tree
 ====================

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -8,7 +8,7 @@ Welcome to directory-tree's documentation!
 
 This package can be used to optimise directory and dataset lookup tables.
 
-Speed comparison agains a recursive lookup approach, shortening the path by
+Speed comparison against a recursive lookup approach, shortening the path by
 one each time and re-testing:
 
 .. program-output:: directory-tree-speed-test


### PR DESCRIPTION
Fixes #5

Output: https://github.com/cclauss/directory-tree/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.